### PR TITLE
Remove deprecated LocalStack environment variables from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,9 @@ services:
     ports:
       - "4566:4566"
       - "4571:4571"
-      - "8082:8082"
     environment:
-      - PROVIDER_OVERRIDE_STEPFUNCTIONS=v2
-      - USE_LIGHT_IMAGE=0
       - DEBUG=1
-      - PORT_WEB_UI=8082
-      - LAMBDA_EXECUTOR=local
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR}
-      - START_WEB=1
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"  # required for some AWS services like AWS Lambda


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Hi😀 Thank you for providing such a useful AWS Prescriptive Guidance!
I successfully followed the steps in this repository and everything worked as expected.
https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/test-aws-infra-localstack-terraform.html

However, I noticed a small issue related to the `docker-compose.yml` configuration for LocalStack.

Currently, the configuration includes some deprecated environment variables, which trigger warnings during execution. Here are the specific warnings I encountered:

- PORT_WEB_UI is deprecated (since 0.12.8)
- HOST_TMP_FOLDER is deprecated (since 1.0.0)
- LAMBDA_EXECUTOR is deprecated (since 2.0.0)
- PROVIDER_OVERRIDE_STEPFUNCTIONS is deprecated (since 4.0.0)

The container image `localstack/localstack:latest` is specified, which means the current version in use is LocalStack v4.
https://hub.docker.com/r/localstack/localstack/tags

```
2025-01-05T23:27:03.831 DEBUG --- [  MainThread] localstack.plugins         : Checking for the usage of deprecated community features and configs...
2025-01-05T23:27:03.831  WARN --- [  MainThread] localstack.deprecations    : PORT_WEB_UI is deprecated (since 0.12.8) and will be removed in upcoming releases of LocalStack! PORT_WEB_UI has been removed, and is not available anymore. Please remove this environment variable.
2025-01-05T23:27:03.831  WARN --- [  MainThread] localstack.deprecations    : HOST_TMP_FOLDER is deprecated (since 1.0.0) and will be removed in upcoming releases of LocalStack! This option has no effect anymore. Please remove this environment variable.
2025-01-05T23:27:03.831  WARN --- [  MainThread] localstack.deprecations    : LAMBDA_EXECUTOR is deprecated (since 2.0.0) and will be removed in upcoming releases of LocalStack! This configuration is obsolete with the new lambda provider https://docs.localstack.cloud/user-guide/aws/lambda/#migrating-to-lambda-v2
Please mount the Docker socket /var/run/docker.sock as a volume when starting LocalStack.
2025-01-05T23:27:03.831  WARN --- [  MainThread] localstack.deprecations    : PROVIDER_OVERRIDE_STEPFUNCTIONS is deprecated (since 4.0.0) and will be removed in upcoming releases of LocalStack! This option is ignored because the legacy StepFunctions provider (v1) has been removed since 4.0.0. Please remove PROVIDER_OVERRIDE_STEPFUNCTIONS.
```

The motivation behind this pull request is to safely remove these deprecated environment variables to ensure the configuration is up-to-date and avoids potential issues in future LocalStack releases.

## Related documents

- https://docs.localstack.cloud/references/configuration/
- https://docs.localstack.cloud/user-guide/aws/lambda/

## Check

It worked in my environment.

```sh
$ terraform test
(snip)
Success! 3 passed, 0 failed.
```

There are no deprecated warnings anymore.

```
localstack  | 2025-01-07T14:06:09.228 DEBUG --- [  MainThread] localstack.plugins         : Checking for the usage of deprecated community features and configs...
```

Could you please review? Thanks a lot 👍

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.